### PR TITLE
Fix fatal error with null response

### DIFF
--- a/src/Dropbox/DropboxResponse.php
+++ b/src/Dropbox/DropboxResponse.php
@@ -1,6 +1,8 @@
 <?php
 namespace Kunnu\Dropbox;
 
+use Kunnu\Dropbox\Exceptions\DropboxClientException;
+
 class DropboxResponse
 {
     /**
@@ -127,5 +129,8 @@ class DropboxResponse
         $body = $this->getBody();
 
         $this->decodedBody = json_decode((string) $body, true);
+        if (is_null($this->decodedBody) || $this->decodedBody === false) {
+            throw new DropboxClientException("Invalid Response.");
+        }
     }
 }


### PR DESCRIPTION
PHP Catchable fatal error:  Argument 1 passed to Kunnu\Dropbox\Models\FileMetadata::__construct() must be of the type array, null given, called in ../kunalvarma05/dropbox-php-sdk/src/Dropbox/Dropbox.php on line 813 and defined in ../kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/FileMetadata.php on line 99