### PR TITLE
Fix bug affecting non-session based data stores

### DIFF
--- a/src/Dropbox/Store/PersistentDataStoreFactory.php
+++ b/src/Dropbox/Store/PersistentDataStoreFactory.php
@@ -3,6 +3,7 @@ namespace Kunnu\Dropbox\Store;
 
 use InvalidArgumentException;
 use Kunnu\Dropbox\Exceptions\DropboxClientException;
+use Kunnu\Dropbox\Store\PersistentDataStoreInterface;
 
 /**
  * Thanks to Facebook
@@ -26,7 +27,7 @@ class PersistentDataStoreFactory
             return new SessionPersistentDataStore();
         }
 
-        if ($store instanceof PersistentDataInterface) {
+        if ($store instanceof PersistentDataStoreInterface) {
             return $store;
         }
 


### PR DESCRIPTION
Looks like a typo that was making this not work at all for environments that have their own session management separate from PHP sessions.