### PR TITLE
Download large file directly to the specified location

### DIFF
--- a/src/Dropbox/DropboxResponse.php
+++ b/src/Dropbox/DropboxResponse.php
@@ -31,7 +31,7 @@ class DropboxResponse
      *
      * @var array
      */
-    protected $decodedBody = [];
+    protected $decodedBody;
 
     /**
      * The original request that returned this response
@@ -47,8 +47,6 @@ class DropboxResponse
      * @param string|null $body
      * @param int|null    $httpStatusCode
      * @param array       $headers
-     *
-     * @throws DropboxClientException
      */
     public function __construct(DropboxRequest $request, $body = null, $httpStatusCode = null, array $headers = [])
     {
@@ -56,9 +54,30 @@ class DropboxResponse
         $this->body = $body;
         $this->httpStatusCode = $httpStatusCode;
         $this->headers = $headers;
+    }
 
-        //Decode the Response Body
-        $this->decodeBody();
+    /**
+     * @param string $body
+     */
+    public function setBody($body)
+    {
+        $this->body = $body;
+    }
+
+    /**
+     * @param int $httpStatusCode
+     */
+    public function setHttpStatusCode($httpStatusCode)
+    {
+        $this->httpStatusCode = $httpStatusCode;
+    }
+
+    /**
+     * @param array $headers
+     */
+    public function setHeaders(array $headers)
+    {
+        $this->headers = $headers;
     }
 
     /**
@@ -88,6 +107,10 @@ class DropboxResponse
      */
     public function getDecodedBody()
     {
+        if ($this->decodedBody === null) {
+            //Decode the Response Body
+            $this->decodeBody();
+        }
         return $this->decodedBody;
     }
 

--- a/src/Dropbox/DropboxResponseToFile.php
+++ b/src/Dropbox/DropboxResponseToFile.php
@@ -1,0 +1,34 @@
+<?php
+namespace Kunnu\Dropbox;
+
+class DropboxResponseToFile extends DropboxResponse
+{
+    /**
+     * @var DropboxFile
+     */
+    protected $file;
+
+    /**
+     * Create a new DropboxResponse instance
+     *
+     * @param DropboxRequest $request
+     * @param DropboxFile $file
+     * @param int|null    $httpStatusCode
+     * @param array       $headers
+     */
+    public function __construct(DropboxRequest $request, DropboxFile $file, $httpStatusCode = null, array $headers = [])
+    {
+        parent::__construct($request, null, $httpStatusCode, $headers);
+        $this->file = $file;
+    }
+
+    public function getBody()
+    {
+        return $this->file->getContents();
+    }
+
+    public function getFilePath()
+    {
+        return $this->file->getFilePath();
+    }
+}

--- a/src/Dropbox/Http/Clients/DropboxGuzzleHttpClient.php
+++ b/src/Dropbox/Http/Clients/DropboxGuzzleHttpClient.php
@@ -67,8 +67,13 @@ class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
             throw new DropboxClientException($rawResponse->getBody());
         }
 
-        //Get the Response Body
-        $body = $this->getResponseBody($rawResponse);
+        if (array_key_exists('sink', $options)) {
+            //Response Body is saved to a file
+            $body = '';
+        } else {
+            //Get the Response Body
+            $body = $this->getResponseBody($rawResponse);
+        }
 
         $rawHeaders = $rawResponse->getHeaders();
         $httpStatusCode = $rawResponse->getStatusCode();

--- a/src/Dropbox/Models/File.php
+++ b/src/Dropbox/Models/File.php
@@ -1,13 +1,15 @@
 <?php
 namespace Kunnu\Dropbox\Models;
 
+use Kunnu\Dropbox\DropboxFile;
+
 class File extends BaseModel
 {
 
     /**
      * The file contents
      *
-     * @var string
+     * @var string|DropboxFile
      */
     protected $contents;
 
@@ -23,7 +25,7 @@ class File extends BaseModel
      * Create a new File instance
      *
      * @param array  $data
-     * @param string $contents
+     * @param string|DropboxFile $contents
      */
     public function __construct(array $data, $contents)
     {
@@ -49,6 +51,9 @@ class File extends BaseModel
      */
     public function getContents()
     {
+        if ($this->contents instanceof DropboxFile) {
+            return $this->contents->getContents();
+        }
         return $this->contents;
     }
 }


### PR DESCRIPTION
Hey!
I have an issue with download of a large file from Dropbox:
```
PHP Fatal error:  Allowed memory size of 268435456 bytes exhausted (tried to allocate 340263665 bytes) in /usr/local/psa/admin/plib/modules/dropbox-backup/vendor/guzzlehttp/psr7/src/Stream.php on line 102
```
I want to use [sink](http://docs.guzzlephp.org/en/latest/request-options.html#sink) option and save the response directly to the file without memory allocation.