### PR TITLE
Adds previous exception to DropBoxClientException

### DIFF
--- a/src/Dropbox/Http/Clients/DropboxGuzzleHttpClient.php
+++ b/src/Dropbox/Http/Clients/DropboxGuzzleHttpClient.php
@@ -1,29 +1,30 @@
 <?php
+
 namespace Kunnu\Dropbox\Http\Clients;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Exception\RequestException;
 use Kunnu\Dropbox\Http\DropboxRawResponse;
+use GuzzleHttp\Exception\BadResponseException;
 use Kunnu\Dropbox\Exceptions\DropboxClientException;
 
 /**
- * DropboxGuzzleHttpClient
+ * DropboxGuzzleHttpClient.
  */
 class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
 {
     /**
-     * GuzzleHttp client
+     * GuzzleHttp client.
      *
      * @var \GuzzleHttp\Client
      */
     protected $client;
 
     /**
-     * Create a new DropboxGuzzleHttpClient instance
+     * Create a new DropboxGuzzleHttpClient instance.
      *
      * @param Client $client GuzzleHttp Client
      */
@@ -34,7 +35,7 @@ class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
     }
 
     /**
-     * Send request to the server and fetch the raw response
+     * Send request to the server and fetch the raw response.
      *
      * @param  string $url     URL/Endpoint to send the request to
      * @param  string $method  Request Method
@@ -59,7 +60,7 @@ class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
         } catch (RequestException $e) {
             $rawResponse = $e->getResponse();
 
-            if (!$rawResponse instanceof ResponseInterface) {
+            if (! $rawResponse instanceof ResponseInterface) {
                 throw new DropboxClientException($e->getMessage(), $e->getCode());
             }
         }
@@ -85,7 +86,7 @@ class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
     }
 
     /**
-     * Get the Response Body
+     * Get the Response Body.
      *
      * @param string|\Psr\Http\Message\ResponseInterface $response Response object
      *

--- a/src/Dropbox/Http/Clients/DropboxGuzzleHttpClient.php
+++ b/src/Dropbox/Http/Clients/DropboxGuzzleHttpClient.php
@@ -2,6 +2,7 @@
 namespace Kunnu\Dropbox\Http\Clients;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -53,6 +54,8 @@ class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
         try {
             //Send the Request
             $rawResponse = $this->client->send($request, $options);
+        } catch (BadResponseException $e) {
+            throw new DropboxClientException($e->getResponse()->getBody(), $e->getCode(), $e);
         } catch (RequestException $e) {
             $rawResponse = $e->getResponse();
 


### PR DESCRIPTION
To be able to find more details why a certain request failed we
needed the information provided by dropbox. Only parsing the message
wasn't a good and stable option. With this change we are able to see
what went wrong internally.