### PR TITLE
Fix uploading large files from stream

### DIFF
--- a/src/Dropbox/DropboxFile.php
+++ b/src/Dropbox/DropboxFile.php
@@ -88,14 +88,19 @@ class DropboxFile
      */
     public static function createByStream($fileName, $resource, $mode = self::MODE_READ)
     {
-        // initialize a new intance
-        $dropboxFile = new self($fileName, $mode);
-
         // create a new stream and set it to the dropbox file
         $stream = \GuzzleHttp\Psr7\stream_for($resource);
         if (!$stream) {
             throw new DropboxClientException('Failed to create DropboxFile instance. Unable to open the given resource.');
         }
+
+        // Try to get the file path from the stream (we'll need this for uploading bigger files)
+        $filePath = $stream->getMetadata('uri');
+        if (!is_null($filePath)) {
+            $fileName = $filePath;
+        }
+
+        $dropboxFile = new self($fileName, $mode);
         $dropboxFile->setStream($stream);
 
         return $dropboxFile;


### PR DESCRIPTION
Uploading bigger files uses an upload session to upload the file in smaller chunks. This session is initialized using the DropboxFile path.
When we create a new DropboxFile from a stream (using the "createyByStream" method), the path wasn't correctly set. The filename was set instead, so when we tried to upload a bigger file from a stream, the upload session tried to retrieve the file using the file name, resulting in an error.
This commit fixes this by setting the stream URI as the DropboxFile path.

Note: This'll only work for a stream that you get from tmpfile. For a regular file pinter, it might only give you the basename.