### PR TITLE
declare DropboxClientException in phpdoc where it could be thrown

### DIFF
--- a/src/Dropbox/Authentication/DropboxAuthHelper.php
+++ b/src/Dropbox/Authentication/DropboxAuthHelper.php
@@ -194,11 +194,12 @@ class DropboxAuthHelper
     /**
      * Get Access Token
      *
-     * @param  string $code        Authorization Code
-     * @param  string $state       CSRF & URL State
+     * @param  string $code Authorization Code
+     * @param  string $state CSRF & URL State
      * @param  string $redirectUri Redirect URI used while getAuthUrl
      *
      * @return \Kunnu\Dropbox\Models\AccessToken
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function getAccessToken($code, $state = null, $redirectUri = null)
     {
@@ -230,6 +231,7 @@ class DropboxAuthHelper
      * Revoke Access Token
      *
      * @return void
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function revokeAccessToken()
     {

--- a/src/Dropbox/Authentication/OAuth2Client.php
+++ b/src/Dropbox/Authentication/OAuth2Client.php
@@ -125,11 +125,12 @@ class OAuth2Client
     /**
      * Get Access Token
      *
-     * @param  string $code        Authorization Code
+     * @param  string $code Authorization Code
      * @param  string $redirectUri Redirect URI used while getAuthorizationUrl
-     * @param  string $grant_type  Grant Type ['authorization_code']
+     * @param  string $grant_type Grant Type ['authorization_code']
      *
      * @return array
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function getAccessToken($code, $redirectUri = null, $grant_type = 'authorization_code')
     {
@@ -165,6 +166,7 @@ class OAuth2Client
      * Disables the access token
      *
      * @return void
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function revokeAccessToken()
     {

--- a/src/Dropbox/Dropbox.php
+++ b/src/Dropbox/Dropbox.php
@@ -97,6 +97,7 @@ class Dropbox
      *
      * @param \Kunnu\Dropbox\DropboxApp
      * @param array $config Configuration Array
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function __construct(DropboxApp $app, array $config = [])
     {
@@ -230,12 +231,13 @@ class Dropbox
     /**
      * Make a HTTP POST Request to the API endpoint type
      *
-     * @param  string $endpoint    API Endpoint to send Request to
-     * @param  array  $params      Request Query Params
+     * @param  string $endpoint API Endpoint to send Request to
+     * @param  array $params Request Query Params
      * @param  string $accessToken Access Token to send with the Request
      *
      * @return \Kunnu\Dropbox\DropboxResponse
-     */
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
+    */
     public function postToAPI($endpoint, array $params = [], $accessToken = null)
     {
         return $this->sendRequest("POST", $endpoint, 'api', $params, $accessToken);
@@ -320,12 +322,13 @@ class Dropbox
     /**
      * Get the contents of a Folder
      *
-     * @param  string $path   Path to the folder. Defaults to root.
-     * @param  array  $params Additional Params
+     * @param  string $path Path to the folder. Defaults to root.
+     * @param  array $params Additional Params
      *
      * @link https://www.dropbox.com/developers/documentation/http/documentation#files-list_folder
      *
      * @return \Kunnu\Dropbox\Models\MetadataCollection
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function listFolder($path = null, array $params = [])
     {
@@ -355,6 +358,7 @@ class Dropbox
      * @link https://www.dropbox.com/developers/documentation/http/documentation#files-list_folder-continue
      *
      * @return \Kunnu\Dropbox\Models\MetadataCollection
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function listFolderContinue($cursor)
     {
@@ -407,12 +411,13 @@ class Dropbox
     /**
      * Get Revisions of a File
      *
-     * @param  string $path   Path to the file
-     * @param  array  $params Additional Params
+     * @param  string $path Path to the file
+     * @param  array $params Additional Params
      *
      * @link https://www.dropbox.com/developers/documentation/http/documentation#files-list_revisions
      *
      * @return \Kunnu\Dropbox\Models\ModelCollection
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function listRevisions($path, array $params = [])
     {
@@ -442,13 +447,14 @@ class Dropbox
     /**
      * Search a folder for files/folders
      *
-     * @param  string $path   Path to search
-     * @param  string $query  Search Query
-     * @param  array  $params Additional Params
+     * @param  string $path Path to search
+     * @param  string $query Search Query
+     * @param  array $params Additional Params
      *
      * @link https://www.dropbox.com/developers/documentation/http/documentation#files-search
      *
      * @return \Kunnu\Dropbox\Models\SearchResults
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function search($path, $query, array $params = [])
     {
@@ -770,12 +776,13 @@ class Dropbox
      * Upload a File to Dropbox
      *
      * @param  string|DropboxFile $dropboxFile DropboxFile object or Path to file
-     * @param  string             $path        Path to upload the file to
-     * @param  array              $params      Additional Params
+     * @param  string $path Path to upload the file to
+     * @param  array $params Additional Params
      *
      * @link https://www.dropbox.com/developers/documentation/http/documentation#files-upload
      *
      * @return \Kunnu\Dropbox\Models\FileMetadata
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function upload($dropboxFile, $path, array $params = [])
     {
@@ -830,16 +837,17 @@ class Dropbox
      * Upload file in sessions/chunks
      *
      * @param  string|DropboxFile $dropboxFile DropboxFile object or Path to file
-     * @param  string             $path        Path to save the file to, on Dropbox
-     * @param  int                $fileSize    The size of the file
-     * @param  int                $chunkSize   The amount of data to upload in each chunk
-     * @param  array              $params      Additional Params
+     * @param  string $path Path to save the file to, on Dropbox
+     * @param  int $fileSize The size of the file
+     * @param  int $chunkSize The amount of data to upload in each chunk
+     * @param  array $params Additional Params
      *
      * @link https://www.dropbox.com/developers/documentation/http/documentation#files-upload_session-start
      * @link https://www.dropbox.com/developers/documentation/http/documentation#files-upload_session-finish
      * @link https://www.dropbox.com/developers/documentation/http/documentation#files-upload_session-append_v2
      *
      * @return \Kunnu\Dropbox\Models\FileMetadata
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function uploadChunked($dropboxFile, $path, $fileSize = null, $chunkSize = null, array $params = array())
     {
@@ -932,12 +940,13 @@ class Dropbox
     /**
      * Make a HTTP POST Request to the Content endpoint type
      *
-     * @param  string      $endpoint     Content Endpoint to send Request to
-     * @param  array       $params       Request Query Params
-     * @param  string      $accessToken  Access Token to send with the Request
+     * @param  string $endpoint Content Endpoint to send Request to
+     * @param  array $params Request Query Params
+     * @param  string $accessToken Access Token to send with the Request
      * @param  DropboxFile $responseFile Save response to the file
      *
      * @return \Kunnu\Dropbox\DropboxResponse
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function postToContent($endpoint, array $params = [], $accessToken = null, DropboxFile $responseFile = null)
     {
@@ -1045,12 +1054,13 @@ class Dropbox
      * Upload a File to Dropbox in a single request
      *
      * @param  string|DropboxFile $dropboxFile DropboxFile object or Path to file
-     * @param  string             $path        Path to upload the file to
-     * @param  array              $params      Additional Params
+     * @param  string $path Path to upload the file to
+     * @param  array $params Additional Params
      *
      * @link https://www.dropbox.com/developers/documentation/http/documentation#files-upload
      *
      * @return \Kunnu\Dropbox\Models\FileMetadata
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function simpleUpload($dropboxFile, $path, array $params = [])
     {
@@ -1209,6 +1219,7 @@ class Dropbox
      * @link https://www.dropbox.com/developers/documentation/http/documentation#users-get_current_account
      *
      * @return \Kunnu\Dropbox\Models\Account
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function getCurrentAccount()
     {
@@ -1228,6 +1239,7 @@ class Dropbox
      * @link https://www.dropbox.com/developers/documentation/http/documentation#users-get_account
      *
      * @return \Kunnu\Dropbox\Models\Account
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function getAccount($account_id)
     {
@@ -1247,6 +1259,7 @@ class Dropbox
      * @link https://www.dropbox.com/developers/documentation/http/documentation#users-get_account_batch
      *
      * @return \Kunnu\Dropbox\Models\AccountList
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function getAccounts(array $account_ids = [])
     {
@@ -1264,6 +1277,7 @@ class Dropbox
      * @link https://www.dropbox.com/developers/documentation/http/documentation#users-get_space_usage
      *
      * @return array
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function getSpaceUsage()
     {

--- a/src/Dropbox/DropboxFile.php
+++ b/src/Dropbox/DropboxFile.php
@@ -161,6 +161,7 @@ class DropboxFile
      * Return the contents of the file
      *
      * @return string
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function getContents()
     {
@@ -184,6 +185,7 @@ class DropboxFile
      * Get the Open File Stream
      *
      * @return \GuzzleHttp\Psr7\Stream
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function getStream()
     {
@@ -310,6 +312,7 @@ class DropboxFile
      * Get the size of the file
      *
      * @return int
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function getSize()
     {

--- a/src/Dropbox/DropboxResponse.php
+++ b/src/Dropbox/DropboxResponse.php
@@ -104,6 +104,7 @@ class DropboxResponse
      * Get the Decoded Body
      *
      * @return array
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function getDecodedBody()
     {

--- a/src/Dropbox/DropboxResponseToFile.php
+++ b/src/Dropbox/DropboxResponseToFile.php
@@ -22,6 +22,9 @@ class DropboxResponseToFile extends DropboxResponse
         $this->file = $file;
     }
 
+    /**
+     * @throws Exceptions\DropboxClientException
+     */
     public function getBody()
     {
         return $this->file->getContents();

--- a/src/Dropbox/Models/File.php
+++ b/src/Dropbox/Models/File.php
@@ -48,6 +48,7 @@ class File extends BaseModel
      * Get the file contents
      *
      * @return string
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     public function getContents()
     {


### PR DESCRIPTION
The API works great, but the code forgets to advise that a DropboxException could be thrown. This PR adds a phpdoc annotation to this effect.