### PR TITLE
Fix tightenco/collect composer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "~6.0",
-        "tightenco/collect": "^5.2"
+        "tightenco/collect": "5.6.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi,
Related with this [issue](https://github.com/tightenco/collect/issues/124) of tightenco/collect, the version 5.7.1 is throwing a warning and crashing in some circustances (running test for instance), to fix that we just have to fix the version to 5.6. I hope that you can merge this PR.

Thanks and Regards.