### PR TITLE
Add __toString to Account model

### DIFF
--- a/src/Dropbox/Models/Account.php
+++ b/src/Dropbox/Models/Account.php
@@ -109,6 +109,16 @@ class Account extends BaseModel
     }
 
     /**
+     * Return full contents of API response as JSON
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return json_encode($this->getData());
+    }
+
+    /**
      * Get Account ID
      *
      * @return string


### PR DESCRIPTION
In my current project I needed the entire contents of the `->getCurrentAccount()` response rather than individual attributes like `->getEmail()` etc.

It isn't documented that you can do this using `->getData()` so I spent quite a while trying to strip characters out of the default object returned.

This pull request simply adds the `__toString()` method to the Account model for when you need to return the entire Account model as JSON.  All existing methods still work, no breaking changes.