### PR TITLE
Add function for getting thumbnail batches.

### DIFF
--- a/src/Dropbox/DropboxClient.php
+++ b/src/Dropbox/DropboxClient.php
@@ -185,7 +185,7 @@ class DropboxClient
         $url = $this->buildUrl($request->getEndpoint(), $request->getEndpointType());
 
         //The Endpoint is content
-        if ($request->getEndpointType() === 'content') {
+        if ($request->getEndpointFormat() === 'content') {
             //Dropbox requires the parameters to be passed
             //through the 'Dropbox-API-Arg' header
             $request->setHeaders(['Dropbox-API-Arg' => json_encode($request->getParams())]);
@@ -218,7 +218,7 @@ class DropboxClient
             $this->buildAuthHeader($request->getAccessToken()),
             $this->buildContentTypeHeader($request->getContentType()),
             $request->getHeaders()
-            );
+        );
 
         //Return the URL, Headers and Request Body
         return [$url, $headers, $requestBody];

--- a/src/Dropbox/DropboxRequest.php
+++ b/src/Dropbox/DropboxRequest.php
@@ -47,6 +47,13 @@ class DropboxRequest
     protected $endpointType = null;
 
     /**
+     * The Endpoint Format for this request
+     *
+     * @var string
+     */
+    protected $endpointFormat = null;
+
+    /**
      * The headers to send with this request
      *
      * @var array
@@ -81,19 +88,29 @@ class DropboxRequest
     /**
      * Create a new DropboxRequest instance
      *
-     * @param string $method       HTTP Method of the Request
-     * @param string $endpoint     API endpoint of the Request
-     * @param string $accessToken  Access Token for the Request
-     * @param string $endpointType Endpoint type ['api'|'content']
-     * @param mixed  $params       Request Params
-     * @param array  $headers      Headers to send along with the Request
+     * @param string $method         HTTP Method of the Request
+     * @param string $endpoint       API endpoint of the Request
+     * @param string $accessToken    Access Token for the Request
+     * @param string $endpointType   Endpoint type ['api'|'content']
+     * @param string $endpointFormat Endpoint format ['rpc'|'content']
+     * @param mixed  $params         Request Params
+     * @param array  $headers        Headers to send along with the Request
      */
-    public function __construct($method, $endpoint, $accessToken, $endpointType = "api", array $params = [], array $headers = [], $contentType = null)
-    {
+    public function __construct(
+        $method,
+        $endpoint,
+        $accessToken,
+        $endpointType = "api",
+        $endpointFormat = "rpc",
+        array $params = [],
+        array $headers = [],
+        $contentType = null
+    ) {
         $this->setMethod($method);
         $this->setEndpoint($endpoint);
         $this->setAccessToken($accessToken);
         $this->setEndpointType($endpointType);
+        $this->setEndpointFormat($endpointFormat);
         $this->setParams($params);
         $this->setHeaders($headers);
 
@@ -112,7 +129,7 @@ class DropboxRequest
         return $this->method;
     }
 
-    /**
+     /**
      * Set the Request Method
      *
      * @param string
@@ -194,6 +211,30 @@ class DropboxRequest
     public function setEndpointType($endpointType)
     {
         $this->endpointType = $endpointType;
+
+        return $this;
+    }
+
+    /**
+     * Get the Endpoint Format of the Request
+     *
+     * @return string
+     */
+    public function getEndpointFormat()
+    {
+        return $this->endpointFormat;
+    }
+
+    /**
+     * Set the Endpoint Format of the Request
+     *
+     * @param string
+     *
+     * @return \Kunnu\Dropbox\DropboxRequest
+     */
+    public function setEndpointFormat($endpointFormat)
+    {
+        $this->endpointFormat = $endpointFormat;
 
         return $this;
     }

--- a/src/Dropbox/Models/ThumbnailList.php
+++ b/src/Dropbox/Models/ThumbnailList.php
@@ -1,0 +1,35 @@
+<?php
+namespace Kunnu\Dropbox\Models;
+
+class ThumbnailList extends ModelCollection
+{
+    /**
+     * Create a new Metadata Collection
+     *
+     * @param array $data Collection Data
+     */
+    public function __construct(array $data)
+    {
+        $processedItems = $this->processItems($data['entries']);
+        parent::__construct($processedItems);
+    }
+
+    /**
+     * Process items and cast them
+     * to Thumbnail Model
+     *
+     * @param array $items Unprocessed Items
+     *
+     * @return array Array of Thumbnail models
+     */
+    protected function processItems(array $items)
+    {
+        $processedItems = [];
+
+        foreach ($items as $entry) {
+            $processedItems[] = new Thumbnail($entry['metadata'], $entry['thumbnail']);
+        }
+
+        return $processedItems;
+    }
+}


### PR DESCRIPTION
Closes #152 

Added the ability to retrieve thumbnails in batches. In order to accomplish this I had to add the ability to have different Endpoint Types and Endpoint Formats. As per the Dropbox documentation the thumbnail batch endpoint uses the Content endpoint, but it requires the RPC format (which is typically used by the regular API). Including the `Dropbox-API-Arg` header throws an error for this endpoint. So I added an additional optional argument for `endpointFormat`. By default it matches the `endpointType`, but added a function to make a call to the Content API with the RPC format.

I did it this way in an attempt to reduce the amount of impactful changes where possible. Instead of changing `postToContent` which would require modifying a lot of calls to that function, I created a new function to use this difference - `postToContentAsRpc`.

Let me know if you'd like it done in a different way. This is a feature I require in my current project to be able to use this package. I'm having to use a patch until this gets implemented.