### PR TITLE
Added support for new Dropbox short lived tokens through Refresh Tokens

### DIFF
--- a/src/Dropbox/Authentication/OAuth2Client.php
+++ b/src/Dropbox/Authentication/OAuth2Client.php
@@ -133,14 +133,26 @@ class OAuth2Client
      */
     public function getAccessToken($code, $redirectUri = null, $grant_type = 'authorization_code')
     {
-        //Request Params
-        $params = [
-        'code' => $code,
-        'grant_type' => $grant_type,
-        'client_id' => $this->getApp()->getClientId(),
-        'client_secret' => $this->getApp()->getClientSecret(),
-        'redirect_uri' => $redirectUri
-        ];
+        if ($grant_type == 'refresh_token') {
+            //Request Params
+            $params = [
+                'grant_type' => $grant_type,
+                'refresh_token' => $code,
+                'client_id' => $this->getApp()->getClientId(),
+                'client_secret' => $this->getApp()->getClientSecret()
+            ];
+        }
+        else
+        {
+            //Request Params
+            $params = [
+                'code' => $code,
+                'grant_type' => $grant_type,
+                'client_id' => $this->getApp()->getClientId(),
+                'client_secret' => $this->getApp()->getClientSecret(),
+                'redirect_uri' => $redirectUri
+            ];
+        }
 
         $params = http_build_query($params);
 

--- a/src/Dropbox/DropboxApp.php
+++ b/src/Dropbox/DropboxApp.php
@@ -30,17 +30,26 @@ class DropboxApp
     protected $accessToken;
 
     /**
+     * The Refresh Token is a long-lived token that can be used to request new short-lived access tokens without
+     * direct interaction from a user in your app.
+     *
+     * @var string
+     */
+    protected $refreshToken;
+
+    /**
      * Create a new Dropbox instance
      *
      * @param string $clientId     Application Client ID
      * @param string $clientSecret Application Client Secret
      * @param string $accessToken  Access Token
      */
-    public function __construct($clientId, $clientSecret, $accessToken = null)
+    public function __construct($clientId, $clientSecret, $accessToken = null, $refreshToken = null)
     {
         $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
         $this->accessToken = $accessToken;
+        $this->refreshToken = $refreshToken;
     }
 
     /**
@@ -71,5 +80,15 @@ class DropboxApp
     public function getAccessToken()
     {
         return $this->accessToken;
+    }
+
+    /**
+     * Get the long lived Refresh Token
+     *
+     * @return string
+     */
+    public function getRefreshToken()
+    {
+        return $this->refreshToken;
     }
 }

--- a/src/Dropbox/Models/AccessToken.php
+++ b/src/Dropbox/Models/AccessToken.php
@@ -46,6 +46,20 @@ class AccessToken extends BaseModel
     protected $teamId;
 
     /**
+     * Refresh token, received when token_access_type = offline
+     *
+     * @var string|null
+     */
+    protected $refreshToken;
+
+    /**
+     * Indicate when the token is expired
+     *
+     * @var string|null
+     */
+    protected $tokenExpiresIn;
+
+    /**
      * Create a new AccessToken instance
      *
      * @param array $data
@@ -60,6 +74,8 @@ class AccessToken extends BaseModel
         $this->uid = $this->getDataProperty('uid');
         $this->accountId = $this->getDataProperty('account_id');
         $this->teamId = $this->getDataProperty('team_id');
+        $this->refreshToken = $this->getDataProperty("refresh_token");
+        $this->tokenExpiresIn = $this->getDataProperty("expires_in");
     }
 
     /**
@@ -121,4 +137,27 @@ class AccessToken extends BaseModel
     {
         return $this->teamId;
     }
+
+    /**
+     * if token_access_type was set to offline, then response will include a refresh token.
+     * This refresh token is long-lived and won't expire automatically.
+     * It can be stored and re-used multiple times.
+     *
+     * @return string|null
+     */
+    public function getRefreshToken()
+    {
+        return $this->refreshToken;
+    }
+
+    /**
+     * Get the length of time that the access token will be valid for
+     *
+     * @return string|null
+     */
+    public function getExpiresIn()
+    {
+        return $this->tokenExpiresIn;
+    }
+
 }


### PR DESCRIPTION
Added suuport for Dropbox Short Lived Tokens as described in this article
https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens

- AuthHelper has a new method called setAccessTokenType where you can choose access token DropboxAuthHelper::TOKEN_ACCESS_TYPE_OFFLINE (default) or DropboxAuthHelper::TOKEN_ACCESS_TYPE_OFFLINE.

- When access token type is set to OFFLINE, calling getAuthUrl will request access token for offline use

- When AuthHelper method getAccessToken is called, two new fields are returned in AccessToken object: $refreshToken and $tokenExpiresIn

- When AuthHelper method getAccessToken new parameter grantType is added and can be used to set if the access token 
requested is DropboxAuthHelper::GRANT_TYPE_AUTHORIZATION_CODE (default for regular tokens) or DropboxAuthHelper::GRANT_TYPE_REFRESH_TOKEN for tokens based on refresh token. 

- If grant type is GRANT_TYPE_REFRESH_TOKEN, the result is an newly token that can be used.

Examples:
Getting auth URL with access token for OFFLINE use
```
        $authHelper = $dropboxClient->getAuthHelper();
        $authHelper->setAccessTokenType(Dropbox\Authentication\DropboxAuthHelper::TOKEN_ACCESS_TYPE_OFFLINE);
        echo $authHelper->getAuthUrl();

```

After that, getting access token after is performed regulary:
```
        $authHelper = $dropboxClient->getAuthHelper();

        var_dump($authHelper->getAccessToken($key));
```
The result AccessToken object will contain $refreshToken and $tokenExpiresIn properties.


Getting a new token based on refresh token:
```
    /**
     * @param string $refreshToken   The refresh token received by AuthHelper->getAccessToken
     * @return Dropbox\Models\AccessToken
     */
    public function refreshAccessToken($refreshToken) {
        $authHelper = $dropboxClient->getAuthHelper();

        var_dump($authHelper->getAccessToken($refreshToken, null, null, Dropbox\Authentication\DropboxAuthHelper::GRANT_TYPE_REFRESH_TOKEN));
    }
```
The result AccessToken object will include $token property with a newly access token to be used.

