### PR TITLE
Depend on guzzle ~7.0

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,6 +1,4 @@
 preset: psr2
 
-linting: true
-
 disabled:
   - single_class_element_per_statement

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "~7.0",
         "tightenco/collect": "^5.2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "~7.0",
+        "guzzlehttp/guzzle": "~6.0|~7.0",
         "tightenco/collect": "^5.2"
     },
     "autoload": {


### PR DESCRIPTION
Any chance we could UP the dependency on guzzle to ~7.0? With this change, the app `files_external_dropbox` could be made compatible with Nextcloud 21.

See DJaeger/files_external_dropbox/issues/32