### PR TITLE
Remove unused composer dependency to tightenco/collect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "~6.0|~7.0",
-        "tightenco/collect": "^5.2"
+        "guzzlehttp/guzzle": "~6.0|~7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Closes https://github.com/kunalvarma05/dropbox-php-sdk/issues/190

As mentioned in the issue, this package require tightenco/collect 5.2 but few of it's method are deprecated in php 8. 
But no need to update it, because this package seems to have never been used in this package.

I detect the dependency on Illuminate\Support\Collection in ModelCollection, but no require on illuminate/support in your composer.json founded, that's another issue i guess.

So for now we can simply remove tightenco/collect as a root requirement.