### PR TITLE
feat: replace tightenco collection with illuminate collection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "~6.0|~7.0",
-        "tightenco/collect": "^5.2"
+        "illuminate/collections": "^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Closes #190

In #191, the fix proposed was to remove the `tightenco/collect` package. However, the `ModelCollection` class depends on the `Collection` class and therefore needs the `Illuminate/Collection` package to be present as a dependency.

This MR replaces `tightenco/collect` with `illuminate/collections@8.*` which works with PHP 7.3+. Since this is a breaking change, it will be released under the `0.3.*` tag.