### PR TITLE
Updated a deprecated function from GuzzleHttp used on DropboxFile

### DIFF
--- a/src/Dropbox/DropboxFile.php
+++ b/src/Dropbox/DropboxFile.php
@@ -331,6 +331,6 @@ class DropboxFile
      */
     public function getMimetype()
     {
-        return \GuzzleHttp\Psr7\mimetype_from_filename($this->path) ?: 'text/plain';
+        return \GuzzleHttp\Psr7\MimeType::fromFilename($this->path) ?: 'text/plain';
     }
 }


### PR DESCRIPTION
### Updated a deprecated function from GuzzleHttp used on DropboxFile
The function `\GuzzleHttp\Psr7\mime_type_from_filename(string $filename)` is deprecated and will be removed in **guzzlehttp/psr7:2.0**

Use **MimeType::fromFilename** instead.

More info: https://docs.aws.amazon.com/aws-sdk-php/v3/api/function-GuzzleHttp.Psr7.mimetype_from_filename.html

### Changes:
- Use **MimeType::fromFilename** instead **mime_type_from_filename** on function **Dropboxfile->getMimetype()**
