### PR TITLE
Dropbox api path root support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ index.php
 composer.lock
 /.idea
 .php_cs.cache
+.DS_Store

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "~6.0|~7.0",
-        "illuminate/collections": "^8.0|^9.0|^10.0"
+        "illuminate/collections": "^8.0|^9.0|^10.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {
@@ -19,6 +20,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^6.0|^7.0|^8.0"
     }
 }

--- a/src/Dropbox/Dropbox.php
+++ b/src/Dropbox/Dropbox.php
@@ -105,7 +105,8 @@ class Dropbox
         $config = array_merge([
             'http_client_handler' => null,
             'random_string_generator' => null,
-            'persistent_data_store' => null
+            'persistent_data_store' => null,
+            'namespace_id' => null
         ], $config);
 
         //Set the app
@@ -116,6 +117,9 @@ class Dropbox
 
         //Make the HTTP Client
         $httpClient = DropboxHttpClientFactory::make($config['http_client_handler']);
+
+        //Set the namespace id for the global header Dropbox-API-Path-Root
+        $httpClient->setNamespace($config['namespace_id']);
 
         //Make and Set the DropboxClient
         $this->client = new DropboxClient($httpClient);

--- a/src/Dropbox/Dropbox.php
+++ b/src/Dropbox/Dropbox.php
@@ -469,6 +469,39 @@ class Dropbox
         return $this->makeModelFromResponse($response);
     }
 
+	/**
+     * Search a folder for files/folders
+     *
+     * @param  string $path   Path to search
+     * @param  string $query  Search Query
+     * @param  array  $params Additional Params
+     *
+     * @link https://www.dropbox.com/developers/documentation/http/documentation#files-search
+     *
+     * @return \Kunnu\Dropbox\Models\SearchResults
+     */
+    public function searchV2($query, array $params = [])
+    {
+        //Specify the root folder as an
+        //empty string rather than as "/"
+        if ($path === '/') {
+            $path = "";
+        }
+
+        //Set the path and query
+        $params['query'] = $query;
+
+		if( !array_key_exists( 'include_highlights', $params ) ){
+			$params['include_highlights'] = false;
+		}
+
+        //Fetch Search Results
+        $response = $this->postToAPI('/files/search_v2', $params);
+
+        //Make and Return the Model
+        return $this->makeModelFromResponse($response);
+    }
+
     /**
      * Create a folder at the given path
      *

--- a/src/Dropbox/Dropbox.php
+++ b/src/Dropbox/Dropbox.php
@@ -480,43 +480,6 @@ class Dropbox
     }
 
     /**
-     * Search a folder for files/folders
-     *
-     * @param string $path Path to search
-     * @param string $query Search Query
-     * @param array $params Additional Params
-     *
-     * @return \Kunnu\Dropbox\Models\ModelInterface
-     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
-     */
-    public function searchV2($path, $query, array $params = [])
-    {
-        //Specify the root folder as an
-        //empty string rather than as "/"
-        if ($path === '/') {
-            $path = "";
-        }
-
-        //Set the path and query
-        $params['path'] = $path;
-        $params['query'] = $query;
-
-		if( !array_key_exists( 'match_field_options', $params ) ){
-            if( array_key_exists( 'include_highlights', $params ) ){
-                $params['match_field_options'] = '{"include_highlights": ' . ( $params["include_highlights"] ? 'true' : 'false' ) . "}";
-            } else {
-                $params['match_field_options'] = '{ "include_highlights": false }';
-            }
-		}
-
-        //Fetch Search Results
-        $response = $this->postToAPI('/files/search_v2', $params);
-
-        //Make and Return the Model
-        return $this->makeModelFromResponse($response);
-    }
-
-    /**
      * Create a folder at the given path
      *
      * @param  string  $path       Path to create

--- a/src/Dropbox/Dropbox.php
+++ b/src/Dropbox/Dropbox.php
@@ -475,18 +475,17 @@ class Dropbox
         return $this->makeModelFromResponse($response);
     }
 
-	/**
+    /**
      * Search a folder for files/folders
      *
-     * @param  string $path   Path to search
-     * @param  string $query  Search Query
-     * @param  array  $params Additional Params
+     * @param string $path Path to search
+     * @param string $query Search Query
+     * @param array $params Additional Params
      *
-     * @link https://www.dropbox.com/developers/documentation/http/documentation#files-search
-     *
-     * @return \Kunnu\Dropbox\Models\SearchResults
+     * @return \Kunnu\Dropbox\Models\ModelInterface
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
-    public function searchV2($query, array $params = [])
+    public function searchV2($path, $query, array $params = [])
     {
         //Specify the root folder as an
         //empty string rather than as "/"
@@ -495,10 +494,15 @@ class Dropbox
         }
 
         //Set the path and query
+        $params['path'] = $path;
         $params['query'] = $query;
 
-		if( !array_key_exists( 'include_highlights', $params ) ){
-			$params['include_highlights'] = false;
+		if( !array_key_exists( 'match_field_options', $params ) ){
+            if( array_key_exists( 'include_highlights', $params ) ){
+                $params['match_field_options'] = '{"include_highlights": ' . ( $params["include_highlights"] ? 'true' : 'false' ) . "}";
+            } else {
+                $params['match_field_options'] = '{ "include_highlights": false }';
+            }
 		}
 
         //Fetch Search Results

--- a/src/Dropbox/Http/Clients/DropboxGuzzleHttpClient.php
+++ b/src/Dropbox/Http/Clients/DropboxGuzzleHttpClient.php
@@ -24,6 +24,11 @@ class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
     protected $client;
 
     /**
+     * @var string|null
+     */
+    protected $namespaceId = null;
+
+    /**
      * Create a new DropboxGuzzleHttpClient instance.
      *
      * @param Client $client GuzzleHttp Client
@@ -33,6 +38,14 @@ class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
         //Set the client
         $this->client = $client ?: new Client();
     }
+
+    /**
+     * @param int $namespaceId The namespace id
+     */
+    public function setNamespace( $namespaceId ){
+        $this->namespaceId = $namespaceId;
+    }
+
 
     /**
      * Send request to the server and fetch the raw response.
@@ -49,6 +62,19 @@ class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
      */
     public function send($url, $method, $body, $headers = [], $options = [])
     {
+        //Create a global header for the namespace
+        if ($this->namespaceId) {
+            $headers = array_merge(
+                $headers,
+                [
+                    'Dropbox-API-Path-Root' => json_encode([
+                        '.tag' => 'namespace_id',
+                        'namespace_id' => $this->namespaceId,
+                    ]),
+                ]
+            );
+        }
+
         //Create a new Request Object
         $request = new Request($method, $url, $headers, $body);
 


### PR DESCRIPTION
# Support for Dropbox-API-Path-Root header

This PR allows users to set the Dropbox-API-Path-Root header globally for the client instantiation. This allows the Dropbox object to be scoped to a team namespace instead of an individual user's namespace.

Information on Dropbox's use of namespaces can be found here: https://developers.dropbox.com/dbx-team-files-guide#namespaces

## Changes

### compser.json
- Added `phpunit` support for versions 7 and 8
- Added `ext-json`  to facilitate creating a json to pass the header data

### Dropbox.php
- Added `namespace_id` to the config options
- Set the namespace id of the http client

### DropboxGuzzleHttpClient.php
- Added a new protected property `namespaceId` of type string|null
- Added a `setNamespaceId()` method which accepts string or null as it's input and sets the protected property
- Updated `send()` to add a `Dropbox-API-Path-Root` header to the headers array if `namespaceId` is set
