### PR TITLE
PHP 8.4/8.5 Compatibility Update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer:v2
+
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Run test suite
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ index.php
 composer.lock
 /.idea
 .php_cs.cache
+.phpunit.cache/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Dropbox SDK v2 for PHP
 ======================================================
 [![Latest Stable Version](https://poser.pugx.org/kunalvarma05/dropbox-php-sdk/v/stable?format=flat-square)](https://packagist.org/packages/kunalvarma05/dropbox-php-sdk)
-[![Build Status](https://img.shields.io/travis/kunalvarma05/dropbox-php-sdk.svg?style=flat-square)](https://travis-ci.org/kunalvarma05/dropbox-php-sdk)
+[![CI](https://img.shields.io/github/actions/workflow/status/nao-pon/dropbox-php-sdk/ci.yml?branch=master&style=flat-square)](https://github.com/nao-pon/dropbox-php-sdk/actions/workflows/ci.yml)
 [![Quality Score](https://img.shields.io/scrutinizer/g/kunalvarma05/dropbox-php-sdk.svg?style=flat-square)](https://scrutinizer-ci.com/g/kunalvarma05/dropbox-php-sdk)
 [![Total Downloads](https://img.shields.io/packagist/dt/kunalvarma05/dropbox-php-sdk.svg?style=flat-square)](https://packagist.org/packages/kunalvarma05/dropbox-php-sdk)
 [![StyleCI](https://styleci.io/repos/61913555/shield?branch=master)](https://styleci.io/repos/61913555)
@@ -9,6 +9,12 @@ Dropbox SDK v2 for PHP
 
 
 An unofficial PHP SDK to work with the [Dropbox API v2](https://www.dropbox.com/developers/documentation/http/documentation).
+
+## Fork Notes
+
+This fork is maintained as a minimal-maintenance branch for elFinder distribution compatibility.
+
+The primary goal is to keep the SDK usable on modern PHP versions and with current dependency stacks, without broad API or behavior changes.
 
 <img src="https://cloud.githubusercontent.com/assets/893057/13731118/b7cf0e4e-e987-11e5-942f-13c53d65da35.png">
 

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,9 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "~6.0|~7.0",
-        "illuminate/collections": "^8.0|^9.0|^10.0|^11.0"
+        "php": "^8.1",
+        "guzzlehttp/guzzle": "^7.0",
+        "illuminate/collections": "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {
@@ -19,6 +20,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^10.5"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,29 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         colors="true">
     <testsuites>
         <testsuite name="DropboxTestSuite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Dropbox/Authentication/DropboxAuthHelper.php
+++ b/src/Dropbox/Authentication/DropboxAuthHelper.php
@@ -52,8 +52,8 @@ class DropboxAuthHelper
      */
     public function __construct(
         OAuth2Client $oAuth2Client,
-        RandomStringGeneratorInterface $randomStringGenerator = null,
-        PersistentDataStoreInterface $persistentDataStore = null
+        ?RandomStringGeneratorInterface $randomStringGenerator = null,
+        ?PersistentDataStoreInterface $persistentDataStore = null
     ) {
         $this->oAuth2Client = $oAuth2Client;
         $this->randomStringGenerator = $randomStringGenerator;

--- a/src/Dropbox/Authentication/OAuth2Client.php
+++ b/src/Dropbox/Authentication/OAuth2Client.php
@@ -51,7 +51,7 @@ class OAuth2Client
      * @param \Kunnu\Dropbox\DropboxClient $client
      * @param \Kunnu\Dropbox\Security\RandomStringGeneratorInterface $randStrGenerator
      */
-    public function __construct(DropboxApp $app, DropboxClient $client, RandomStringGeneratorInterface $randStrGenerator = null)
+    public function __construct(DropboxApp $app, DropboxClient $client, ?RandomStringGeneratorInterface $randStrGenerator = null)
     {
         $this->app = $app;
         $this->client = $client;

--- a/src/Dropbox/Dropbox.php
+++ b/src/Dropbox/Dropbox.php
@@ -257,7 +257,7 @@ class Dropbox
      *
      * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
-    public function sendRequest($method, $endpoint, $endpointType = 'api', array $params = [], $accessToken = null, DropboxFile $responseFile = null)
+    public function sendRequest($method, $endpoint, $endpointType = 'api', array $params = [], $accessToken = null, ?DropboxFile $responseFile = null)
     {
         //Access Token
         $accessToken = $this->getAccessToken() ? $this->getAccessToken() : $accessToken;
@@ -948,7 +948,7 @@ class Dropbox
      * @return \Kunnu\Dropbox\DropboxResponse
      * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
-    public function postToContent($endpoint, array $params = [], $accessToken = null, DropboxFile $responseFile = null)
+    public function postToContent($endpoint, array $params = [], $accessToken = null, ?DropboxFile $responseFile = null)
     {
         return $this->sendRequest("POST", $endpoint, 'content', $params, $accessToken, $responseFile);
     }

--- a/src/Dropbox/DropboxClient.php
+++ b/src/Dropbox/DropboxClient.php
@@ -143,7 +143,7 @@ class DropboxClient
      *
      * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
-    public function sendRequest(DropboxRequest $request, DropboxResponse $response = null)
+    public function sendRequest(DropboxRequest $request, ?DropboxResponse $response = null)
     {
         //Method
         $method = $request->getMethod();

--- a/src/Dropbox/Http/Clients/DropboxGuzzleHttpClient.php
+++ b/src/Dropbox/Http/Clients/DropboxGuzzleHttpClient.php
@@ -28,7 +28,7 @@ class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
      *
      * @param Client $client GuzzleHttp Client
      */
-    public function __construct(Client $client = null)
+    public function __construct(?Client $client = null)
     {
         //Set the client
         $this->client = $client ?: new Client();

--- a/tests/DropboxFileTest.php
+++ b/tests/DropboxFileTest.php
@@ -7,37 +7,21 @@ class DropboxFileTest extends TestCase
 {
     protected $stream;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->stream = fopen(__FILE__, 'r');
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
-        fclose($this->stream);
+        if (is_resource($this->stream)) {
+            fclose($this->stream);
+        }
     }
 
     public function testGetStreamOrFilePathReturnsStringWhenConstructedNormally()
     {
-        /** @var \PHPUnit_Framework_MockObject_MockObject|DropboxFile $dropboxFile */
-        $dropboxFile = $this->getMockBuilder(DropboxFile::class)
-            ->setMethods(['getFilePath', 'getStream', 'isCreatedFromStream'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $dropboxFile
-            ->expects($this->any())
-            ->method('getFilePath')
-            ->willReturn('/i/am/a/file');
-
-        $dropboxFile
-            ->expects($this->never())
-            ->method('getStream');
-
-        $dropboxFile
-            ->expects($this->atLeastOnce())
-            ->method('isCreatedFromStream')
-            ->willReturn(false);
+        $dropboxFile = new DropboxFile('/i/am/a/file');
 
         $result = $dropboxFile->getStreamOrFilePath();
 
@@ -46,28 +30,10 @@ class DropboxFileTest extends TestCase
 
     public function testGetStreamOrFilePathReturnsStringWhenConstructedWithStream()
     {
-        /** @var \PHPUnit_Framework_MockObject_MockObject|DropboxFile $dropboxFile */
-        $dropboxFile = $this->getMockBuilder(DropboxFile::class)
-            ->setMethods(['getFilePath', 'getStream', 'isCreatedFromStream'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $dropboxFile
-            ->expects($this->never())
-            ->method('getFilePath');
-
-        $dropboxFile
-            ->expects($this->any())
-            ->method('getStream')
-            ->willReturn($this->stream);
-
-        $dropboxFile
-            ->expects($this->atLeastOnce())
-            ->method('isCreatedFromStream')
-            ->willReturn(true);
+        $dropboxFile = DropboxFile::createByStream('/i/am/a/file', $this->stream);
 
         $result = $dropboxFile->getStreamOrFilePath();
 
-        self::assertSame($this->stream, $result);
+        self::assertSame($dropboxFile->getStream(), $result);
     }
 }


### PR DESCRIPTION
- Fix PHP 8.4 implicit nullable deprecations
- Ensure compatibility with PHP 8.5
- Update composer constraints (Guzzle 7 support)
- Add CI for PHP 8.1–8.5
- Clarify fork maintenance scope